### PR TITLE
Feature - Version bump to 2.4.1

### DIFF
--- a/odr-audioenc.spec
+++ b/odr-audioenc.spec
@@ -34,13 +34,13 @@
 # Names and versions of the (sub)packages
 # See https://www.redhat.com/archives/rpm-list/2000-October/msg00216.html
 %define main_name odr-audioenc
-%define main_version 2.3.1
+%define main_version 2.4.1
 %define main_release 1%{?dist}
 
 %define toolame_dab_name toolame-dab-odr
 # Version relates to libtoolame-dab/HISTORY
 %define libtoolame_dab_version 0.2l.odr
-%define libtoolame_dab_release 4%{?dist}
+%define libtoolame_dab_release 5%{?dist}
 %define libtoolame_dab_license LGPLv2+
 
 %define service_user odr-audioenc
@@ -182,6 +182,9 @@ exit 0
 
 
 %changelog
+* Tue Dec 24 2019 Christian Affolter <c.affolter@purplehaze.ch> - 2.4.1-1
+- Version bump to 2.4.1 
+
 * Sat Oct 27 2018 Christian Affolter <c.affolter@purplehaze.ch> - 2.3.1-1
 - Version bump to 2.3.1
 

--- a/odr-audioenc.spec
+++ b/odr-audioenc.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package odr-audioenc and subpackage toolame-dab-odr
 #
-# Copyright (c) 2016 - 2018 Radio Bern RaBe
+# Copyright (c) 2016 - 2019 Radio Bern RaBe
 #                           http://www.rabe.ch
 #
 # This program is free software: you can redistribute it and/or


### PR DESCRIPTION
This PR updates the odr-audioenc to the latest upstream [2.4.1](https://github.com/Opendigitalradio/ODR-AudioEnc/releases/tag/v2.4.1) version.

Upstream [ChangeLog](https://github.com/Opendigitalradio/ODR-AudioEnc/blob/781c2c69c62a434bed64ff3cfa6d009ed3c479c1/ChangeLog#L1-L4) and [release announcement](https://groups.google.com/forum/#!msg/crc-mmbtools/dXG_o8MvbAs/P97ebXMgCAAJ)